### PR TITLE
Use step-security/harden-runner

### DIFF
--- a/.github/workflows/AIForOrcas.Client.Web.yaml
+++ b/.github/workflows/AIForOrcas.Client.Web.yaml
@@ -34,6 +34,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup .NET Core
@@ -59,6 +62,9 @@ jobs:
     needs:
     - build
     steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
     - name: Artifacts cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/AIForOrcas.Server.yaml
+++ b/.github/workflows/AIForOrcas.Server.yaml
@@ -32,6 +32,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup .NET Core
@@ -57,6 +60,9 @@ jobs:
     needs:
     - build
     steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
     - name: Artifacts cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/NotificationSystem.yaml
+++ b/.github/workflows/NotificationSystem.yaml
@@ -28,6 +28,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup .NET Core
@@ -53,6 +56,9 @@ jobs:
     needs:
     - build
     steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
     - name: Artifacts cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Turning on harden-runner in "audit" mode is the first step in hardening github workflow jobs.

For more details see https://github.com/step-security/harden-runner