### PR TITLE
Update orca-hls-utils to latest github commit

### DIFF
--- a/InferenceSystem/requirements.txt
+++ b/InferenceSystem/requirements.txt
@@ -25,4 +25,4 @@ opencv-python
 boto3
 pytz
 opencensus-ext-azure
-orca-hls-utils
+git+https://github.com/orcasound/orca-hls-utils.git@master#egg=orca-hls-utils


### PR DESCRIPTION
Instead of waiting for PyPI release
To get timestamp fix for now

Fixes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency sourcing to fetch a package directly from its upstream repository instead of the package registry, improving installation reliability and version alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->